### PR TITLE
Avoid ambiguous rule

### DIFF
--- a/style/dirlistings.xsl
+++ b/style/dirlistings.xsl
@@ -338,7 +338,7 @@
 
 <!-- ============================================================ -->
 
-<xsl:template match="li[contains(@class,'first')]" mode="patchMenu">
+<xsl:template match="li[contains(@class,'first')]" mode="patchMenu" priority="10">
   <xsl:param name="title"/>
   <li>
     <xsl:copy-of select="@*"/>


### PR DESCRIPTION
If a "tab" has a single child, the child will be both "first" and "last". This patch avoids an ambiguous rule error in XSLT.
